### PR TITLE
Harmonize angular and react starters

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,4 @@
+{
+  "verbose": true,
+  "ignore": [".git/*", "src/*", "node_modules/*", "dist/*", "build/*"]
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "postinstall": "npm run typings; npm run build;",
     "typings": "rimraf typings && tsd install && tsd link",
-    "dev": "NODE_ENV=development webpack-dev-server --display-error-details --display-cached",
+    "dev": "NODE_ENV=development nodemon server.js",
     "start": "NODE_ENV=production node server.js",
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
@@ -62,6 +62,7 @@
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.3",
+    "nodemon": "^1.8.1",
     "ramda": "^0.18.0",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.4.3",
@@ -75,6 +76,6 @@
     "typescript": "^1.7.3",
     "url-loader": "^0.5.6",
     "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.14.0"
+    "webpack-dev-middleware": "^1.4.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,12 +1,27 @@
 const express = require('express');
+const webpack = require('webpack');
 const winston = require('winston');
 const chalk = require('chalk');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const DOMAIN = '0.0.0.0';
 
-app.use('/', express.static('dist'));
+if (process.env.NODE_ENV !== 'production') {
+  const config = require('./webpack.config');
+  const compiler = webpack(config);
+
+  winston.info('Bundling webpack... Please wait.');
+
+  app.use(require('webpack-dev-middleware')(compiler, {
+    publicPath: config.output.publicPath,
+    stats: {
+        colors: true,
+        reasons: true
+    }
+  }));
+}
+
+app.get('*', express.static('dist'));
 
 app.listen(PORT, (err) => {
   if (err) {
@@ -14,5 +29,5 @@ app.listen(PORT, (err) => {
     return;
   }
 
-  winston.info(`Listening at http://${ chalk.green(DOMAIN) }:${ chalk.yellow(PORT) }`);
+  winston.info(`Listening on port ${ chalk.yellow(PORT) }`);
 });

--- a/src/components/counter/counter.ts
+++ b/src/components/counter/counter.ts
@@ -16,11 +16,10 @@ class CounterController {
     '$ngRedux',
     '$scope'
   ];
-  
+
   constructor($ngRedux, $scope: ng.IScope) {
     const unsubscribe = $ngRedux.connect(
       this.mapStateToThis, CounterActions)(this);
-      
     $scope.$on('$destroy', unsubscribe);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ const createLogger = require('redux-logger');
 const ngRedux = require('ng-redux');
 const thunk = require('redux-thunk');
 
+declare var __DEV__: any;
+
 angular.module('counter', [ngRedux])
   .config([
     '$ngReduxProvider',
@@ -14,7 +16,7 @@ angular.module('counter', [ngRedux])
       let middleware = [thunk];
 
       if (__DEV__) {
-        middleware.push(logger)
+        middleware.push(logger);
       }
 
       $ngReduxProvider.createStoreWith(rootReducer, middleware);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,15 +9,16 @@ const basePlugins = [
     __DEV__: process.env.NODE_ENV !== 'production',
     __PRODUCTION__: process.env.NODE_ENV === 'production'
   }),
-  new webpack.optimize.CommonsChunkPlugin('vendor', '[name].[hash].bundle.js'),
+  new webpack.optimize.CommonsChunkPlugin('vendor', '[name].[hash].js'),
   new HtmlWebpackPlugin({
     template: './src/index.html',
-    inject: 'body',
-    minify: false
+    inject: 'body'
   })
 ];
 
-const devPlugins = [];
+const devPlugins = [
+  new webpack.NoErrorsPlugin(),
+];
 
 const prodPlugins = [
   new webpack.optimize.UglifyJsPlugin({
@@ -32,12 +33,7 @@ const plugins = basePlugins
   .concat(process.env.NODE_ENV === 'development' ? devPlugins : []);
 
 module.exports = {
-  
-  stats: {
-    colors: true,
-    reasons: true
-  },
-  
+
   entry: {
     app: './src/index.ts',
     vendor: [
@@ -49,21 +45,21 @@ module.exports = {
       'redux-logger'
     ]
   },
-  
+
   output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: '[name].[hash].bundle.js',
+    path: path.join(__dirname, 'dist'),
+    filename: '[name].[hash].js',
     publicPath: "/",
-    sourceMapFilename: '[name].[hash].bundle.js.map',
+    sourceMapFilename: '[name].[hash].js.map',
     chunkFilename: '[id].chunk.js'
   },
-  
+
   devtool: 'source-map',
-  
+
   resolve: {
     extensions: ['', '.webpack.js', '.web.js', '.ts', '.js']
   },
-  
+
   plugins: plugins,
 
   module: {
@@ -81,12 +77,5 @@ module.exports = {
       { test: /\.woff2/, loader: 'url' },
       { test: /\.ttf/, loader: 'url' },
     ]
-  },
-  
-  devServer: {
-    inline: true,
-    colors: true,
-    contentBase: './dist',
-    publicPath: '/'
   }
 }


### PR DESCRIPTION
Updates to run scripts:
- no more webpack-dev-server: instead devmode runs `nodemon` and applies webpack middleware to the express app.  This gives a 'watch' mode that works for changes to both client and server code.
- fixed npm start to actually serve all static assets, not just `index.html`
- misc tweaks to harmonize the webpack config as much as possible with the react starter.