### PR TITLE
Use serve-webpack-client to serve the client in dev and prod modes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "redux": "^3.0.4",
     "redux-logger": "^2.1.4",
     "redux-thunk": "^1.0.0",
+    "serve-webpack-client": "0.0.4",
     "winston": "^2.1.1"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -1,27 +1,17 @@
 const express = require('express');
-const webpack = require('webpack');
 const winston = require('winston');
 const chalk = require('chalk');
+const path = require('path');
+const serveWebpackClient = require('serve-webpack-client');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-if (process.env.NODE_ENV !== 'production') {
-  const config = require('./webpack.config');
-  const compiler = webpack(config);
-
-  winston.info('Bundling webpack... Please wait.');
-
-  app.use(require('webpack-dev-middleware')(compiler, {
-    publicPath: config.output.publicPath,
-    stats: {
-        colors: true,
-        reasons: true
-    }
-  }));
-}
-
-app.get('*', express.static('dist'));
+app.use(serveWebpackClient({
+  distPath: path.join(__dirname, 'dist'),
+  indexFileName: 'index.html',
+  webpackConfig: require('./webpack.config')
+}));
 
 app.listen(PORT, (err) => {
   if (err) {


### PR DESCRIPTION
This makes sure history api fallback routing works in dev and prod modes, and that we use the minified bundle in prod and the watcher middleware in dev.