### PR TITLE
Add `cssnano` to end of `postcss` plugin chain to compress compiled `css` in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "chai": "^3.5.0",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
+    "cssnano": "^3.5.2",
     "es5-shim": "^4.5.7",
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,28 @@ const plugins = basePlugins
   .concat(process.env.NODE_ENV === 'production' ? prodPlugins : [])
   .concat(process.env.NODE_ENV === 'development' ? devPlugins : []);
 
+const postcssBasePlugins = [
+  require('postcss-modules-local-by-default'),
+  require('postcss-import')({
+    addDependencyTo: webpack,
+  }),
+  require('postcss-cssnext')({
+    browsers: ['ie >= 8', 'last 2 versions'],
+  }),
+];
+const postcssDevPlugins = [];
+const postcssProdPlugins = [
+  require('cssnano')({
+    safe: true,
+    sourcemap: true,
+    autoprefixer:false,
+  }),
+];
+
+const postcssPlugins = postcssBasePlugins
+  .concat(process.env.NODE_ENV === 'production' ? postcssProdPlugins : [])
+  .concat(process.env.NODE_ENV === 'development' ? postcssDevPlugins : []);
+
 module.exports = {
 
   entry: {
@@ -94,15 +116,7 @@ module.exports = {
     ]
   },
 
-  postcss: function() {
-    return [
-      require('postcss-modules-local-by-default'),
-      require('postcss-import')({
-        addDependencyTo: webpack
-      }),
-      require('postcss-cssnext')({
-        browsers: ['ie >= 8', 'last 2 versions']
-      }),
-    ];
-  }
+  postcss: function postcssInit() {
+    return postcssPlugins;
+  },
 };


### PR DESCRIPTION
Add `cssnano` to end of `postcss` plugin chain to compress compiled `css` when `NODE_ENV=production` only.

Split `postcss` plugins into an explicit `base` set concatenated with a `dev` or `prod` set to achieve this behaviour. This follows the pattern used by the general `webpack` plugins.

Connected to rangle/rangle-starter#55