### PR TITLE
Import shims, angular and ngcomponentrouter in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
+import 'es5-shim';
+import 'es6-shim';
+import 'es6-promise';
+
 import * as angular from 'angular';
 
+import 'ngcomponentrouter';
 import './store/configure-store';
 
 // Global styles

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,12 +68,6 @@ module.exports = {
 
   entry: {
     app: './src/index.ts',
-    shims: [
-      'es5-shim',
-      'es6-shim',
-      'es6-promise',
-    ],
-    angular: ['angular', 'ngcomponentrouter'],
   },
 
   output: {


### PR DESCRIPTION
Removed shims, angular and ngcomponentrouter from webpack config and explicitly imported them in index.ts to be consistent with other starters

Tested updated version on Chrome and IE.

Connected to rangle/rangle-starter#100