### PR TITLE
Applied recent lessons learned for Autoprefixer

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,3 @@
+Last 2 versions
+Safari >= 8
+IE >= 9

--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -25,7 +25,7 @@ exports.html = {
 
 exports.css = {
   test: /\.css$/,
-  loader: 'style!css!postcss',
+  loader: 'style!css?-minimize!postcss',
   exclude: /node_modules/,
 };
 

--- a/webpack/postcss.js
+++ b/webpack/postcss.js
@@ -7,9 +7,7 @@ const postcssBasePlugins = [
   require('postcss-import')({
     addDependencyTo: webpack,
   }),
-  require('postcss-cssnext')({
-    browsers: ['ie >= 9', 'last 2 versions'],
-  }),
+  require('postcss-cssnext'),
 ];
 const postcssDevPlugins = [];
 const postcssProdPlugins = [


### PR DESCRIPTION
Work around a well known webpack.UglifyJSPlugin behaviour that strips -webpack prefixes regardless of autoprefixer settings.

Separate the browser version specs into a browserslist file.

Connected to rangle/rangle-starter#137